### PR TITLE
Accept `Any` filter for `find_one` methods

### DIFF
--- a/motor-stubs/core.pyi
+++ b/motor-stubs/core.pyi
@@ -434,7 +434,7 @@ class AgnosticCollection(AgnosticBaseProperties):
     ) -> int: ...
     def find(
         self,
-        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
+        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]
         ] = None,
@@ -471,6 +471,7 @@ class AgnosticCollection(AgnosticBaseProperties):
     ) -> AgnosticCursor: ...
     async def find_one(
         self,
+        # ``find_one`` can convert non-mapping types to a filter that looks like ``{"_id": <value>}``.
         filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]

--- a/motor-stubs/core.pyi
+++ b/motor-stubs/core.pyi
@@ -434,7 +434,7 @@ class AgnosticCollection(AgnosticBaseProperties):
     ) -> int: ...
     def find(
         self,
-        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]
         ] = None,
@@ -471,7 +471,7 @@ class AgnosticCollection(AgnosticBaseProperties):
     ) -> AgnosticCursor: ...
     async def find_one(
         self,
-        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]
         ] = None,

--- a/motor-stubs/motor_asyncio.pyi
+++ b/motor-stubs/motor_asyncio.pyi
@@ -153,7 +153,7 @@ class AsyncIOMotorCollection(core.AgnosticCollection):
     ) -> AsyncIOMotorLatentCommandCursor: ...
     def find(
         self,
-        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]
         ] = None,
@@ -273,7 +273,7 @@ class AsyncIOMotorGridFSBucket(motor_gridfs.AgnosticGridFSBucket):
     ) -> None: ...
     async def find(
         self,
-        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
         skip: int = 0,
         limit: int = 0,
         no_cursor_timeout: bool = False,

--- a/motor-stubs/motor_asyncio.pyi
+++ b/motor-stubs/motor_asyncio.pyi
@@ -153,7 +153,7 @@ class AsyncIOMotorCollection(core.AgnosticCollection):
     ) -> AsyncIOMotorLatentCommandCursor: ...
     def find(
         self,
-        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
+        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         projection: typing.Optional[
             typing.Mapping[str, typing.Any] | typing.Iterable[str]
         ] = None,
@@ -273,7 +273,7 @@ class AsyncIOMotorGridFSBucket(motor_gridfs.AgnosticGridFSBucket):
     ) -> None: ...
     async def find(
         self,
-        filter: typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]] = None,
+        filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         skip: int = 0,
         limit: int = 0,
         no_cursor_timeout: bool = False,


### PR DESCRIPTION
According to motor and motor-asyncio, we can provide either 
 - a mapping like `{str: Any}`
 - any other object, used as `{"_id": Any}`

> filter (optional): a dictionary specifying the query to be performed OR any other type to be used as the value for a query for "_id".
> - [`find_one` documentation](https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html#motor.motor_asyncio.AsyncIOMotorCollection.find_one)

We could either use the type `typing.Optional[typing.Union[typing.Mapping[str, typing.Any], typing.Any]]` or `typing.Optional[typing.Any]`. If the second syntax is more concise and simple, the first one put an emphasis on the two possibilities: the mapping or any other type.

It does not seem possible to use an Any type for `find_one_and_delete`, `find_one_and_replace` and `find_one_and_update`

---

As pointed by @L0RD-ZER0, and unlike [`find` documentation](https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html#motor.motor_asyncio.AsyncIOMotorCollection.find), `find` fail at runtime if we don't provide a mapping.