### PR TITLE
Fix typo: ``casual_consistency`` -> ``causal_consistency``

### DIFF
--- a/motor-stubs/core.pyi
+++ b/motor-stubs/core.pyi
@@ -131,7 +131,7 @@ class AgnosticClient(AgnosticBaseProperties):
     ) -> typing.Dict[str, typing.Any]: ...
     async def start_session(
         self,
-        casual_consistency: typing.Optional[bool] = None,
+        causal_consistency: typing.Optional[bool] = None,
         default_transaction_options: typing.Optional[
             pymongo.client_session.TransactionOptions
         ] = None,

--- a/motor-stubs/motor_asyncio.pyi
+++ b/motor-stubs/motor_asyncio.pyi
@@ -53,7 +53,7 @@ class AsyncIOMotorClient(core.AgnosticClient):
     ) -> AsyncIOMotorCommandCursor: ...
     async def start_session(
         self,
-        casual_consistency: typing.Optional[bool] = None,
+        causal_consistency: typing.Optional[bool] = None,
         default_transaction_options: typing.Optional[
             pymongo.client_session.TransactionOptions
         ] = None,


### PR DESCRIPTION
There was a typo in arguments of ``MotorClient.start_session(...)`` with ``causal_consistency`` mistyped as ``casual_consistency``. This aims to remedy the typo.