### PR TITLE
Fix definition of find methods

### DIFF
--- a/motor-stubs/motor_asyncio.pyi
+++ b/motor-stubs/motor_asyncio.pyi
@@ -271,7 +271,7 @@ class AsyncIOMotorGridFSBucket(motor_gridfs.AgnosticGridFSBucket):
         read_preferences: typing.Optional[_ReadPreferences] = None,
         collection: typing.Optional[AsyncIOMotorCollection] = None,
     ) -> None: ...
-    async def find(
+    def find(
         self,
         filter: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         skip: int = 0,

--- a/motor-stubs/motor_gridfs.pyi
+++ b/motor-stubs/motor_gridfs.pyi
@@ -143,7 +143,7 @@ class AgnosticGridFSBucket(object):
         revision: int = -1,
         session: Optional[_Session] = None,
     ) -> None: ...
-    async def find(
+    def find(
         self,
         filter: Optional[Mapping[str, Any]] = None,
         skip: int = 0,


### PR DESCRIPTION
Hi, we've just started using `Motor-Types` and saw a mismatch between these types and the code. These `find` methods immediately return async cursors to be awaited; see https://motor.readthedocs.io/en/stable/api-tornado/gridfs.html#motor.motor_tornado.MotorGridFSBucket.find.